### PR TITLE
Fix BME280 sensor reporting  for SignalK server after AdaFruit update

### DIFF
--- a/openplotterI2c/openplotterI2cRead.py
+++ b/openplotterI2c/openplotterI2cRead.py
@@ -41,8 +41,7 @@ def work_BME280(name,data):
 	humidityKey = data['data'][2]['SKkey']
 
 	if pressureKey or temperatureKey or humidityKey:
-		import adafruit_bme280
-
+		from adafruit_bme280 import basic as adafruit_bme280
 		address = data['address']
 		i2c = busio.I2C(board.SCL, board.SDA)
 		sensor = adafruit_bme280.Adafruit_BME280_I2C(i2c, address=int(address, 16))


### PR DESCRIPTION
Fixes BME280 sensors **not** reporting to the SignalK server after AdaFruit updated the BME280 library. 
Thanks to [Jay_cd33 @ OpenMarine forums #18.](https://forum.openmarine.net/showthread.php?tid=3542&page=2&highlight=SignalK+no+data%2Fgauges)
