### PR TITLE
Fix/ads1x15 pin constants

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh repo *)",
+      "Bash(gh api *)"
+    ]
+  }
+}

--- a/openplotterI2c/openplotterI2cRead.py
+++ b/openplotterI2c/openplotterI2cRead.py
@@ -240,6 +240,7 @@ def main():
 
 					elif i2c_sensors[i]['type'] == 'ADS1115' or i2c_sensors[i]['type'] == 'ADS1015':
 						from adafruit_ads1x15.analog_in import AnalogIn
+						from adafruit_ads1x15.ads1x15 import Pin as ADS_Pin
 						if i2c_sensors[i]['type'] == 'ADS1115':
 							import adafruit_ads1x15.ads1115 as ADS11
 							if i2c_sensors[i]['channel'] == 0:
@@ -248,10 +249,10 @@ def main():
 							else:
 								if i2c_sensors[i]['address']:
 									instances.append({'name':i,'type':'ADS1115','tick':[now,now,now,now],'sensor':i2c_sensors[i],'object':ADS11.ADS1115(muxInstances[i2c_sensors[i]['address']][i2c_sensors[i]['channel']-1])})
-							if instances[-1]['sensor']['data'][0]['SKkey']: instances[-1]['sensor']['data'][0]['object'] = AnalogIn(instances[-1]['object'], ADS11.ADS1115.P0)
-							if instances[-1]['sensor']['data'][1]['SKkey']: instances[-1]['sensor']['data'][1]['object'] = AnalogIn(instances[-1]['object'], ADS11.ADS1115.P1)
-							if instances[-1]['sensor']['data'][2]['SKkey']: instances[-1]['sensor']['data'][2]['object'] = AnalogIn(instances[-1]['object'], ADS11.ADS1115.P2)
-							if instances[-1]['sensor']['data'][3]['SKkey']: instances[-1]['sensor']['data'][3]['object'] = AnalogIn(instances[-1]['object'], ADS11.ADS1115.P3)
+							if instances[-1]['sensor']['data'][0]['SKkey']: instances[-1]['sensor']['data'][0]['object'] = AnalogIn(instances[-1]['object'], ADS_Pin.A0)
+							if instances[-1]['sensor']['data'][1]['SKkey']: instances[-1]['sensor']['data'][1]['object'] = AnalogIn(instances[-1]['object'], ADS_Pin.A1)
+							if instances[-1]['sensor']['data'][2]['SKkey']: instances[-1]['sensor']['data'][2]['object'] = AnalogIn(instances[-1]['object'], ADS_Pin.A2)
+							if instances[-1]['sensor']['data'][3]['SKkey']: instances[-1]['sensor']['data'][3]['object'] = AnalogIn(instances[-1]['object'], ADS_Pin.A3)
 
 						elif i2c_sensors[i]['type'] == 'ADS1015':
 							import adafruit_ads1x15.ads1015 as ADS10
@@ -261,10 +262,10 @@ def main():
 							else:
 								if i2c_sensors[i]['address']:
 									instances.append({'name':i,'type':'ADS1015','tick':[now,now,now,now],'sensor':i2c_sensors[i],'object':ADS10.ADS1015(muxInstances[i2c_sensors[i]['address']][i2c_sensors[i]['channel']-1])})
-							if instances[-1]['sensor']['data'][0]['SKkey']: instances[-1]['sensor']['data'][0]['object'] = AnalogIn(instances[-1]['object'], ADS10.ADS1015.P0)
-							if instances[-1]['sensor']['data'][1]['SKkey']: instances[-1]['sensor']['data'][1]['object'] = AnalogIn(instances[-1]['object'], ADS10.ADS1015.P1)
-							if instances[-1]['sensor']['data'][2]['SKkey']: instances[-1]['sensor']['data'][2]['object'] = AnalogIn(instances[-1]['object'], ADS10.ADS1015.P2)
-							if instances[-1]['sensor']['data'][3]['SKkey']: instances[-1]['sensor']['data'][3]['object'] = AnalogIn(instances[-1]['object'], ADS10.ADS1015.P3)
+							if instances[-1]['sensor']['data'][0]['SKkey']: instances[-1]['sensor']['data'][0]['object'] = AnalogIn(instances[-1]['object'], ADS_Pin.A0)
+							if instances[-1]['sensor']['data'][1]['SKkey']: instances[-1]['sensor']['data'][1]['object'] = AnalogIn(instances[-1]['object'], ADS_Pin.A1)
+							if instances[-1]['sensor']['data'][2]['SKkey']: instances[-1]['sensor']['data'][2]['object'] = AnalogIn(instances[-1]['object'], ADS_Pin.A2)
+							if instances[-1]['sensor']['data'][3]['SKkey']: instances[-1]['sensor']['data'][3]['object'] = AnalogIn(instances[-1]['object'], ADS_Pin.A3)
 
 						gain = 1
 						if 'sensorSettings' in instances[-1]['sensor']:
@@ -294,7 +295,12 @@ def main():
 						sys.stdout.flush()
 				else: i2c_sensors[i]['error'] = ''
 
-			conf2.set('I2C', 'sensors', str(i2c_sensors))
+			i2c_sensors_save = {}
+			for _n, _s in i2c_sensors.items():
+				_sc = {k: v for k, v in _s.items() if k != 'data'}
+				_sc['data'] = [{k: v for k, v in d.items() if k not in ('object', 'ranges')} for d in _s['data']]
+				i2c_sensors_save[_n] = _sc
+			conf2.set('I2C', 'sensors', str(i2c_sensors_save))
 
 			#read sensors
 			if not instances:

--- a/openplotterI2c/openplotterI2cRead.py
+++ b/openplotterI2c/openplotterI2cRead.py
@@ -248,10 +248,10 @@ def main():
 							else:
 								if i2c_sensors[i]['address']:
 									instances.append({'name':i,'type':'ADS1115','tick':[now,now,now,now],'sensor':i2c_sensors[i],'object':ADS11.ADS1115(muxInstances[i2c_sensors[i]['address']][i2c_sensors[i]['channel']-1])})
-							if instances[-1]['sensor']['data'][0]['SKkey']: instances[-1]['sensor']['data'][0]['object'] = AnalogIn(instances[-1]['object'], ADS11.P0)
-							if instances[-1]['sensor']['data'][1]['SKkey']: instances[-1]['sensor']['data'][1]['object'] = AnalogIn(instances[-1]['object'], ADS11.P1)
-							if instances[-1]['sensor']['data'][2]['SKkey']: instances[-1]['sensor']['data'][2]['object'] = AnalogIn(instances[-1]['object'], ADS11.P2)
-							if instances[-1]['sensor']['data'][3]['SKkey']: instances[-1]['sensor']['data'][3]['object'] = AnalogIn(instances[-1]['object'], ADS11.P3)
+							if instances[-1]['sensor']['data'][0]['SKkey']: instances[-1]['sensor']['data'][0]['object'] = AnalogIn(instances[-1]['object'], ADS11.ADS1115.P0)
+							if instances[-1]['sensor']['data'][1]['SKkey']: instances[-1]['sensor']['data'][1]['object'] = AnalogIn(instances[-1]['object'], ADS11.ADS1115.P1)
+							if instances[-1]['sensor']['data'][2]['SKkey']: instances[-1]['sensor']['data'][2]['object'] = AnalogIn(instances[-1]['object'], ADS11.ADS1115.P2)
+							if instances[-1]['sensor']['data'][3]['SKkey']: instances[-1]['sensor']['data'][3]['object'] = AnalogIn(instances[-1]['object'], ADS11.ADS1115.P3)
 
 						elif i2c_sensors[i]['type'] == 'ADS1015':
 							import adafruit_ads1x15.ads1015 as ADS10
@@ -261,10 +261,10 @@ def main():
 							else:
 								if i2c_sensors[i]['address']:
 									instances.append({'name':i,'type':'ADS1015','tick':[now,now,now,now],'sensor':i2c_sensors[i],'object':ADS10.ADS1015(muxInstances[i2c_sensors[i]['address']][i2c_sensors[i]['channel']-1])})
-							if instances[-1]['sensor']['data'][0]['SKkey']: instances[-1]['sensor']['data'][0]['object'] = AnalogIn(instances[-1]['object'], ADS10.P0)
-							if instances[-1]['sensor']['data'][1]['SKkey']: instances[-1]['sensor']['data'][1]['object'] = AnalogIn(instances[-1]['object'], ADS10.P1)
-							if instances[-1]['sensor']['data'][2]['SKkey']: instances[-1]['sensor']['data'][2]['object'] = AnalogIn(instances[-1]['object'], ADS10.P2)
-							if instances[-1]['sensor']['data'][3]['SKkey']: instances[-1]['sensor']['data'][3]['object'] = AnalogIn(instances[-1]['object'], ADS10.P3)
+							if instances[-1]['sensor']['data'][0]['SKkey']: instances[-1]['sensor']['data'][0]['object'] = AnalogIn(instances[-1]['object'], ADS10.ADS1015.P0)
+							if instances[-1]['sensor']['data'][1]['SKkey']: instances[-1]['sensor']['data'][1]['object'] = AnalogIn(instances[-1]['object'], ADS10.ADS1015.P1)
+							if instances[-1]['sensor']['data'][2]['SKkey']: instances[-1]['sensor']['data'][2]['object'] = AnalogIn(instances[-1]['object'], ADS10.ADS1015.P2)
+							if instances[-1]['sensor']['data'][3]['SKkey']: instances[-1]['sensor']['data'][3]['object'] = AnalogIn(instances[-1]['object'], ADS10.ADS1015.P3)
 
 						gain = 1
 						if 'sensorSettings' in instances[-1]['sensor']:


### PR DESCRIPTION
Fix ADS1115/ADS1015 support for adafruit-circuitpython-ads1x15 v3.x

  Problem

  Two bugs broke ADS1115 (and ADS1015) support after upgrading to adafruit-circuitpython-ads1x15 v3.0.2.

  Bug 1 — API change: v3.x removed the P0–P3 pin constants from the ADS1115/ADS1015 classes. Accessing ADS1115.P0 raised:
  Error processing ADS1115: type object 'ADS1115' has no attribute 'P0'

  Bug 2 — Channels disappearing from UI after editing: After assigning a Signal K path to a channel and saving, all four channels disappeared from the UI (though data continued flowing to Signal K). The read service
  adds runtime-only keys (object, ranges) directly into the shared sensor data dict and then writes str(i2c_sensors) back to openplotter.conf. The object key serializes as <AnalogIn object at 0x...> — not valid
  Python. When the UI later calls eval() on that string it fails, falls back to {}, and shows an empty list.

  Changes

  openplotterI2cRead.py

  - Import Pin from adafruit_ads1x15.ads1x15 and replace all ADS1115.P0–P3 / ADS1015.P0–P3 references with Pin.A0–A3 (covers both ADS1115 and ADS1015).
  - Before writing sensors back to openplotter.conf, build a clean serializable copy that strips the runtime-only keys object and ranges from each data entry. The error key is preserved so the UI can still highlight
  failing sensors in red.

  For users upgrading from a previous version

  If you already configured an ADS1115/ADS1015 sensor and your channels have disappeared, your openplotter.conf may contain the corrupted entry. Run this once to clean it:

  python3 << 'EOF'
  import configparser

  conf = configparser.ConfigParser()
  conf.read('/home/pi/.openplotter/openplotter.conf')
  try:
      sensors = eval(conf.get('I2C', 'sensors'))
      for sensor in sensors.values():
          for d in sensor.get('data', []):
              d.pop('object', None)
              d.pop('ranges', None)
      conf.set('I2C', 'sensors', str(sensors))
      with open('/home/pi/.openplotter/openplotter.conf', 'w') as f:
          conf.write(f)
      print('Done — restart the OpenPlotter i2c service.')
  except Exception as e:
      print('Could not parse config:', e)
  EOF

  Then restart the i2c service (or reboot). Your channels and Signal K paths will reappear.
  The cleanup script covers any user who hit the same corrupted config.